### PR TITLE
Support for multiple whitespace

### DIFF
--- a/streamplay.py
+++ b/streamplay.py
@@ -60,7 +60,7 @@ while True:
         username = re.search(r"\w+", response).group(0)
         message = CHAT_MSG.sub("", response)
         message = message.strip("\r\n")
-        args = message.split(" ")
+        args = message.split()
         for arg in args:
             try:
                 if arg in keys.keys():


### PR DESCRIPTION
A change as suggested by Pixel-Pop on Discord, changed message.split(" ") to message.split() on line 63, to allow for multiple whitespace characters without breaking shit